### PR TITLE
Potential fix for Issue #1

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -47,7 +47,7 @@ module.exports = grammar({
         float: $ => /-?[0-9][0-9_]*\.([0-9][0-9_]*)?/,
         string: $ => /"[^"]*"/,
 
-        word: $ => /[a-zA-Z0-9]+/,
+        word: $ => /[a-zA-Z0-9_]+/,
         _reg: $ => /%?[a-z0-9]+/,
         reg: $ => choice($._reg, $.word),
         meta_ident: $ => /\.[a-z_]+/,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -391,7 +391,7 @@
     },
     "word": {
       "type": "PATTERN",
-      "value": "[a-zA-Z0-9]+"
+      "value": "[a-zA-Z0-9_]+"
     },
     "_reg": {
       "type": "PATTERN",

--- a/src/parser.c
+++ b/src/parser.c
@@ -377,7 +377,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '\n') ADVANCE(17);
       if (lookahead == '"') ADVANCE(1);
       if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(81);
+          lookahead == ';') ADVANCE(80);
       if (lookahead == '%') ADVANCE(12);
       if (lookahead == '(') ADVANCE(19);
       if (lookahead == ')') ADVANCE(20);
@@ -385,36 +385,36 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '+') ADVANCE(29);
       if (lookahead == ',') ADVANCE(21);
       if (lookahead == '-') ADVANCE(30);
-      if (lookahead == '.') ADVANCE(79);
+      if (lookahead == '.') ADVANCE(78);
       if (lookahead == '/') ADVANCE(2);
       if (lookahead == ':') ADVANCE(18);
       if (lookahead == '[') ADVANCE(28);
       if (lookahead == ']') ADVANCE(31);
-      if (lookahead == '_') ADVANCE(80);
-      if (lookahead == 'b') ADVANCE(71);
-      if (lookahead == 'd') ADVANCE(69);
-      if (lookahead == 'p') ADVANCE(67);
-      if (lookahead == 'q') ADVANCE(70);
-      if (lookahead == 'r') ADVANCE(57);
-      if (lookahead == 'w') ADVANCE(60);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == 'b') ADVANCE(70);
+      if (lookahead == 'd') ADVANCE(68);
+      if (lookahead == 'p') ADVANCE(66);
+      if (lookahead == 'q') ADVANCE(69);
+      if (lookahead == 'r') ADVANCE(56);
+      if (lookahead == 'w') ADVANCE(59);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 1:
-      if (lookahead == '"') ADVANCE(53);
+      if (lookahead == '"') ADVANCE(52);
       if (lookahead != 0) ADVANCE(1);
       END_STATE();
     case 2:
-      if (lookahead == '/') ADVANCE(81);
+      if (lookahead == '/') ADVANCE(80);
       END_STATE();
     case 3:
-      if (lookahead == '0') ADVANCE(42);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(43);
+      if (lookahead == '0') ADVANCE(43);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(44);
       END_STATE();
     case 4:
-      if (lookahead == '0') ADVANCE(44);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(45);
+      if (lookahead == '0') ADVANCE(45);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(46);
       END_STATE();
     case 5:
       if (lookahead == 'e') ADVANCE(6);
@@ -433,19 +433,20 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '\r' ||
           lookahead == ' ') SKIP(9)
       if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(81);
+          lookahead == ';') ADVANCE(80);
       if (lookahead == '%') ADVANCE(12);
       if (lookahead == '/') ADVANCE(2);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(76);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(75);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
       END_STATE();
     case 10:
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(10)
       if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(81);
+          lookahead == ';') ADVANCE(80);
       if (lookahead == '/') ADVANCE(2);
       if (lookahead == 'p') ADVANCE(8);
       if (lookahead == 'r') ADVANCE(5);
@@ -457,7 +458,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 12:
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(77);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(76);
       END_STATE();
     case 13:
       if (eof) ADVANCE(16);
@@ -466,14 +467,14 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == ' ') SKIP(13)
       if (lookahead == '\n') ADVANCE(17);
       if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(81);
+          lookahead == ';') ADVANCE(80);
       if (lookahead == '%') ADVANCE(12);
-      if (lookahead == '.') ADVANCE(79);
+      if (lookahead == '.') ADVANCE(78);
       if (lookahead == '/') ADVANCE(2);
-      if (lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 14:
       if (eof) ADVANCE(16);
@@ -483,24 +484,24 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '\n') ADVANCE(17);
       if (lookahead == '"') ADVANCE(1);
       if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(81);
+          lookahead == ';') ADVANCE(80);
       if (lookahead == '%') ADVANCE(12);
       if (lookahead == '(') ADVANCE(19);
       if (lookahead == '*') ADVANCE(32);
       if (lookahead == '-') ADVANCE(3);
-      if (lookahead == '.') ADVANCE(79);
+      if (lookahead == '.') ADVANCE(78);
       if (lookahead == '/') ADVANCE(2);
-      if (lookahead == '0') ADVANCE(39);
+      if (lookahead == '0') ADVANCE(40);
       if (lookahead == ':') ADVANCE(18);
       if (lookahead == '[') ADVANCE(28);
-      if (lookahead == '_') ADVANCE(80);
-      if (lookahead == 'b') ADVANCE(71);
-      if (lookahead == 'd') ADVANCE(69);
-      if (lookahead == 'q') ADVANCE(70);
-      if (lookahead == 'w') ADVANCE(60);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(40);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == 'b') ADVANCE(70);
+      if (lookahead == 'd') ADVANCE(68);
+      if (lookahead == 'q') ADVANCE(69);
+      if (lookahead == 'w') ADVANCE(59);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(41);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       END_STATE();
     case 15:
       if (eof) ADVANCE(16);
@@ -509,17 +510,17 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == ' ') SKIP(15)
       if (lookahead == '\n') ADVANCE(17);
       if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(81);
+          lookahead == ';') ADVANCE(80);
       if (lookahead == '%') ADVANCE(12);
       if (lookahead == '-') ADVANCE(4);
-      if (lookahead == '.') ADVANCE(79);
+      if (lookahead == '.') ADVANCE(78);
       if (lookahead == '/') ADVANCE(2);
-      if (lookahead == '0') ADVANCE(37);
+      if (lookahead == '0') ADVANCE(35);
       if (lookahead == ':') ADVANCE(18);
-      if (lookahead == '_') ADVANCE(80);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(38);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(36);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       END_STATE();
     case 16:
       ACCEPT_TOKEN(ts_builtin_sym_end);
@@ -541,46 +542,46 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 22:
       ACCEPT_TOKEN(anon_sym_byte);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(79);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 23:
       ACCEPT_TOKEN(anon_sym_word);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(79);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 24:
       ACCEPT_TOKEN(anon_sym_dword);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(79);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 25:
       ACCEPT_TOKEN(anon_sym_qword);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(79);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 26:
       ACCEPT_TOKEN(anon_sym_ptr);
       END_STATE();
     case 27:
       ACCEPT_TOKEN(anon_sym_ptr);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(79);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 28:
       ACCEPT_TOKEN(anon_sym_LBRACK);
@@ -602,105 +603,105 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 34:
       ACCEPT_TOKEN(anon_sym_rel);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(79);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 35:
       ACCEPT_TOKEN(sym_int);
-      if (lookahead == '.') ADVANCE(80);
-      if (lookahead == '_') ADVANCE(48);
-      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(36);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(35);
-      if (('G' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+      if (lookahead == '.') ADVANCE(79);
+      if (lookahead == '_') ADVANCE(38);
+      if (lookahead == 'x') ADVANCE(71);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(36);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(73);
       END_STATE();
     case 36:
       ACCEPT_TOKEN(sym_int);
-      if (lookahead == '.') ADVANCE(80);
-      if (lookahead == '_') ADVANCE(48);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(36);
-      if (('G' <= lookahead && lookahead <= 'Z') ||
-          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(79);
+      if (lookahead == '_') ADVANCE(38);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(36);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(73);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 37:
       ACCEPT_TOKEN(sym_int);
-      if (lookahead == '.') ADVANCE(80);
-      if (lookahead == '_') ADVANCE(46);
-      if (lookahead == 'x') ADVANCE(72);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(38);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(79);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          lookahead == '_') ADVANCE(39);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(37);
+      if (('G' <= lookahead && lookahead <= 'Z')) ADVANCE(73);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 38:
       ACCEPT_TOKEN(sym_int);
-      if (lookahead == '.') ADVANCE(80);
-      if (lookahead == '_') ADVANCE(46);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(38);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+      if (lookahead == '.') ADVANCE(79);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(38);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       END_STATE();
     case 39:
       ACCEPT_TOKEN(sym_int);
-      if (lookahead == '.') ADVANCE(49);
-      if (lookahead == '_') ADVANCE(41);
-      if (lookahead == 'x') ADVANCE(72);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(40);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(79);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(39);
+      if (('G' <= lookahead && lookahead <= 'Z') ||
+          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       END_STATE();
     case 40:
       ACCEPT_TOKEN(sym_int);
-      if (lookahead == '.') ADVANCE(49);
-      if (lookahead == '_') ADVANCE(41);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(40);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+      if (lookahead == '.') ADVANCE(48);
+      if (lookahead == '_') ADVANCE(42);
+      if (lookahead == 'x') ADVANCE(71);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(41);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(73);
       END_STATE();
     case 41:
       ACCEPT_TOKEN(sym_int);
-      if (lookahead == '.') ADVANCE(49);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(41);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(80);
+      if (lookahead == '.') ADVANCE(48);
+      if (lookahead == '_') ADVANCE(42);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(41);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(73);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 42:
       ACCEPT_TOKEN(sym_int);
-      if (lookahead == '.') ADVANCE(50);
-      if (lookahead == 'x') ADVANCE(11);
+      if (lookahead == '.') ADVANCE(48);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(43);
+          lookahead == '_') ADVANCE(42);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       END_STATE();
     case 43:
       ACCEPT_TOKEN(sym_int);
-      if (lookahead == '.') ADVANCE(50);
+      if (lookahead == '.') ADVANCE(49);
+      if (lookahead == 'x') ADVANCE(11);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(43);
+          lookahead == '_') ADVANCE(44);
       END_STATE();
     case 44:
       ACCEPT_TOKEN(sym_int);
-      if (lookahead == 'x') ADVANCE(11);
+      if (lookahead == '.') ADVANCE(49);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(45);
+          lookahead == '_') ADVANCE(44);
       END_STATE();
     case 45:
       ACCEPT_TOKEN(sym_int);
+      if (lookahead == 'x') ADVANCE(11);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(45);
+          lookahead == '_') ADVANCE(46);
       END_STATE();
     case 46:
       ACCEPT_TOKEN(sym_int);
       if (('0' <= lookahead && lookahead <= '9') ||
           lookahead == '_') ADVANCE(46);
-      if (lookahead == '.' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(80);
       END_STATE();
     case 47:
       ACCEPT_TOKEN(sym_int);
@@ -710,276 +711,268 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(47);
       END_STATE();
     case 48:
-      ACCEPT_TOKEN(sym_int);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(48);
+      ACCEPT_TOKEN(sym_float);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(50);
       if (lookahead == '.' ||
-          ('G' <= lookahead && lookahead <= 'Z') ||
-          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(80);
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(79);
       END_STATE();
     case 49:
       ACCEPT_TOKEN(sym_float);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(51);
-      if (lookahead == '.' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(80);
       END_STATE();
     case 50:
       ACCEPT_TOKEN(sym_float);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(52);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(50);
+      if (lookahead == '.' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(79);
       END_STATE();
     case 51:
       ACCEPT_TOKEN(sym_float);
       if (('0' <= lookahead && lookahead <= '9') ||
           lookahead == '_') ADVANCE(51);
-      if (lookahead == '.' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(80);
       END_STATE();
     case 52:
-      ACCEPT_TOKEN(sym_float);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(52);
+      ACCEPT_TOKEN(sym_string);
       END_STATE();
     case 53:
-      ACCEPT_TOKEN(sym_string);
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(79);
+      if (lookahead == 'd') ADVANCE(23);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 54:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == 'd') ADVANCE(23);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(79);
+      if (lookahead == 'd') ADVANCE(24);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 55:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == 'd') ADVANCE(24);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(79);
+      if (lookahead == 'd') ADVANCE(25);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 56:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == 'd') ADVANCE(25);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(79);
+      if (lookahead == 'e') ADVANCE(58);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 57:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == 'e') ADVANCE(59);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(79);
+      if (lookahead == 'e') ADVANCE(22);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 58:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == 'e') ADVANCE(22);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(79);
+      if (lookahead == 'l') ADVANCE(34);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 59:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == 'l') ADVANCE(34);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(79);
+      if (lookahead == 'o') ADVANCE(63);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 60:
       ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(79);
       if (lookahead == 'o') ADVANCE(64);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 61:
       ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(79);
       if (lookahead == 'o') ADVANCE(65);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 62:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == 'o') ADVANCE(66);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(79);
+      if (lookahead == 'r') ADVANCE(27);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 63:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == 'r') ADVANCE(27);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(79);
+      if (lookahead == 'r') ADVANCE(53);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 64:
       ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(79);
       if (lookahead == 'r') ADVANCE(54);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 65:
       ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(79);
       if (lookahead == 'r') ADVANCE(55);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 66:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == 'r') ADVANCE(56);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(79);
+      if (lookahead == 't') ADVANCE(62);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 67:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == 't') ADVANCE(63);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(79);
+      if (lookahead == 't') ADVANCE(57);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 68:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == 't') ADVANCE(58);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(79);
+      if (lookahead == 'w') ADVANCE(60);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 69:
       ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(79);
       if (lookahead == 'w') ADVANCE(61);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 70:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == 'w') ADVANCE(62);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(79);
+      if (lookahead == 'y') ADVANCE(67);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 71:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == 'y') ADVANCE(68);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(79);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(39);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(37);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(72);
+      if (('G' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       END_STATE();
     case 72:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(36);
+      if (lookahead == '.') ADVANCE(79);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(73);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(35);
-      if (('G' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(73);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(72);
       END_STATE();
     case 73:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(79);
       if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(73);
       END_STATE();
     case 74:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.' ||
-          lookahead == '_') ADVANCE(80);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(75);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
       END_STATE();
     case 75:
       ACCEPT_TOKEN(sym_word);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 76:
-      ACCEPT_TOKEN(sym_word);
+      ACCEPT_TOKEN(sym__reg);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(76);
       END_STATE();
     case 77:
-      ACCEPT_TOKEN(sym__reg);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(77);
-      END_STATE();
-    case 78:
       ACCEPT_TOKEN(sym_meta_ident);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(78);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(77);
       if (lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(80);
+          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(79);
       END_STATE();
-    case 79:
+    case 78:
       ACCEPT_TOKEN(sym__ident);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(78);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(77);
       if (lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(80);
+          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(79);
       END_STATE();
-    case 80:
+    case 79:
       ACCEPT_TOKEN(sym__ident);
       if (lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(80);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(79);
       END_STATE();
-    case 81:
+    case 80:
       ACCEPT_TOKEN(sym_line_comment);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(81);
+          lookahead != '\n') ADVANCE(80);
       END_STATE();
     default:
       return false;


### PR DESCRIPTION
Hi, thanks so much for this work! I'm currently using this downstream to implement autocomplete in an [assembly LSP](https://github.com/bergercookie/asm-lsp). I was browsing the repo and saw Issue #1 , and tried fixing it by adding "_" to the set of allowed characters for the ``word`` type in ``grammar.js``. I tested this on a minimal example file for the issue:
``mov [ebr_drive_number], dl``
using tree-sitter's CLI. Running ``tree-sitter parse`` on the file *before* the change produced the following output:

```
(program [0, 0] - [1, 0]
  (instruction [0, 0] - [0, 26]
    kind: (word [0, 0] - [0, 3])
    (ptr [0, 4] - [0, 22]
      (reg [0, 5] - [0, 8]
        (word [0, 5] - [0, 8]))
      (ERROR [0, 8] - [0, 21]))
    (ident [0, 24] - [0, 26]
      (reg [0, 24] - [0, 26]
        (word [0, 24] - [0, 26])))))
test.asm        0 ms    (ERROR [0, 8] - [0, 21])
```
And after the change:

```
(program [0, 0] - [1, 0]
  (instruction [0, 0] - [0, 26]
    kind: (word [0, 0] - [0, 3])
    (ptr [0, 4] - [0, 22]
      (reg [0, 5] - [0, 21]
        (word [0, 5] - [0, 21])))
    (ident [0, 24] - [0, 26]
      (reg [0, 24] - [0, 26]
        (word [0, 24] - [0, 26])))))
```
I wasn't super sure on the testing/ validation procedure for this grammar, so if this change introduces undesired behavior in other places or otherwise breaks things, I apologize. 
Thanks again for this repo!

Closes #1 