### PR TITLE
feat: support multiple items after meta ident

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -14,8 +14,15 @@ module.exports = grammar({
                 $.label,
                 $.instruction,
             ),
-
-        meta: $ => seq(field('kind', $.meta_ident), optional(choice($.ident, $.int))),
+        
+        meta: $ => seq(
+            field('kind', $.meta_ident),
+            optional(choice(
+                $.ident,
+                seq($.int, repeat(seq(',', $.int))),
+                seq($.float, repeat(seq(',', $.float))),
+            ))
+        ),
         label: $ => seq($.ident, ':', optional(seq('(', $.ident, ')'))),
         instruction: $ => seq(field('kind', $.word), sep(',', $._expr)),
 

--- a/grammar.js
+++ b/grammar.js
@@ -14,15 +14,16 @@ module.exports = grammar({
                 $.label,
                 $.instruction,
             ),
-        
-        meta: $ => seq(
-            field('kind', $.meta_ident),
-            optional(choice(
-                $.ident,
-                seq($.int, repeat(seq(',', $.int))),
-                seq($.float, repeat(seq(',', $.float))),
-            ))
-        ),
+
+        meta: $ =>
+            seq(
+                field('kind', $.meta_ident),
+                optional(choice(
+                    $.ident,
+                    seq($.int, repeat(seq(',', $.int))),
+                    seq($.float, repeat(seq(',', $.float))),
+                )),
+            ),
         label: $ => seq($.ident, ':', optional(seq('(', $.ident, ')'))),
         instruction: $ => seq(field('kind', $.word), sep(',', $._expr)),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -91,8 +91,54 @@
                   "name": "ident"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "int"
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "int"
+                    },
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "int"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "float"
+                    },
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "float"
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
               ]
             },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -91,9 +91,13 @@
       }
     },
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "float",
+          "named": true
+        },
         {
           "type": "ident",
           "named": true

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,9 +6,9 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 50
-#define LARGE_STATE_COUNT 6
-#define SYMBOL_COUNT 38
+#define STATE_COUNT 60
+#define LARGE_STATE_COUNT 5
+#define SYMBOL_COUNT 40
 #define ALIAS_COUNT 0
 #define TOKEN_COUNT 26
 #define EXTERNAL_TOKEN_COUNT 0
@@ -18,10 +18,10 @@
 
 enum {
   anon_sym_LF = 1,
-  anon_sym_COLON = 2,
-  anon_sym_LPAREN = 3,
-  anon_sym_RPAREN = 4,
-  anon_sym_COMMA = 5,
+  anon_sym_COMMA = 2,
+  anon_sym_COLON = 3,
+  anon_sym_LPAREN = 4,
+  anon_sym_RPAREN = 5,
   anon_sym_byte = 6,
   anon_sym_word = 7,
   anon_sym_dword = 8,
@@ -53,16 +53,18 @@ enum {
   sym_ident = 34,
   aux_sym_program_repeat1 = 35,
   aux_sym_program_repeat2 = 36,
-  aux_sym_instruction_repeat1 = 37,
+  aux_sym_meta_repeat1 = 37,
+  aux_sym_meta_repeat2 = 38,
+  aux_sym_instruction_repeat1 = 39,
 };
 
 static const char * const ts_symbol_names[] = {
   [ts_builtin_sym_end] = "end",
   [anon_sym_LF] = "\n",
+  [anon_sym_COMMA] = ",",
   [anon_sym_COLON] = ":",
   [anon_sym_LPAREN] = "(",
   [anon_sym_RPAREN] = ")",
-  [anon_sym_COMMA] = ",",
   [anon_sym_byte] = "byte",
   [anon_sym_word] = "word",
   [anon_sym_dword] = "dword",
@@ -94,16 +96,18 @@ static const char * const ts_symbol_names[] = {
   [sym_ident] = "ident",
   [aux_sym_program_repeat1] = "program_repeat1",
   [aux_sym_program_repeat2] = "program_repeat2",
+  [aux_sym_meta_repeat1] = "meta_repeat1",
+  [aux_sym_meta_repeat2] = "meta_repeat2",
   [aux_sym_instruction_repeat1] = "instruction_repeat1",
 };
 
 static const TSSymbol ts_symbol_map[] = {
   [ts_builtin_sym_end] = ts_builtin_sym_end,
   [anon_sym_LF] = anon_sym_LF,
+  [anon_sym_COMMA] = anon_sym_COMMA,
   [anon_sym_COLON] = anon_sym_COLON,
   [anon_sym_LPAREN] = anon_sym_LPAREN,
   [anon_sym_RPAREN] = anon_sym_RPAREN,
-  [anon_sym_COMMA] = anon_sym_COMMA,
   [anon_sym_byte] = anon_sym_byte,
   [anon_sym_word] = anon_sym_word,
   [anon_sym_dword] = anon_sym_dword,
@@ -135,6 +139,8 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_ident] = sym_ident,
   [aux_sym_program_repeat1] = aux_sym_program_repeat1,
   [aux_sym_program_repeat2] = aux_sym_program_repeat2,
+  [aux_sym_meta_repeat1] = aux_sym_meta_repeat1,
+  [aux_sym_meta_repeat2] = aux_sym_meta_repeat2,
   [aux_sym_instruction_repeat1] = aux_sym_instruction_repeat1,
 };
 
@@ -147,6 +153,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
+  [anon_sym_COMMA] = {
+    .visible = true,
+    .named = false,
+  },
   [anon_sym_COLON] = {
     .visible = true,
     .named = false,
@@ -156,10 +166,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [anon_sym_RPAREN] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_COMMA] = {
     .visible = true,
     .named = false,
   },
@@ -287,6 +293,14 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
+  [aux_sym_meta_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_meta_repeat2] = {
+    .visible = false,
+    .named = false,
+  },
   [aux_sym_instruction_repeat1] = {
     .visible = false,
     .named = false,
@@ -370,6 +384,16 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [47] = 47,
   [48] = 48,
   [49] = 49,
+  [50] = 50,
+  [51] = 51,
+  [52] = 52,
+  [53] = 53,
+  [54] = 54,
+  [55] = 55,
+  [56] = 56,
+  [57] = 57,
+  [58] = 58,
+  [59] = 59,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -377,48 +401,48 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(18);
+      if (eof) ADVANCE(19);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(0)
-      if (lookahead == '\n') ADVANCE(19);
+      if (lookahead == '\n') ADVANCE(20);
       if (lookahead == '"') ADVANCE(1);
       if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(82);
-      if (lookahead == '%') ADVANCE(14);
-      if (lookahead == '(') ADVANCE(21);
-      if (lookahead == ')') ADVANCE(22);
-      if (lookahead == '*') ADVANCE(34);
-      if (lookahead == '+') ADVANCE(31);
-      if (lookahead == ',') ADVANCE(23);
-      if (lookahead == '-') ADVANCE(32);
-      if (lookahead == '.') ADVANCE(80);
+          lookahead == ';') ADVANCE(83);
+      if (lookahead == '%') ADVANCE(15);
+      if (lookahead == '(') ADVANCE(23);
+      if (lookahead == ')') ADVANCE(24);
+      if (lookahead == '*') ADVANCE(35);
+      if (lookahead == '+') ADVANCE(32);
+      if (lookahead == ',') ADVANCE(21);
+      if (lookahead == '-') ADVANCE(33);
+      if (lookahead == '.') ADVANCE(81);
       if (lookahead == '/') ADVANCE(2);
-      if (lookahead == ':') ADVANCE(20);
-      if (lookahead == '[') ADVANCE(30);
-      if (lookahead == ']') ADVANCE(33);
-      if (lookahead == 'b') ADVANCE(72);
-      if (lookahead == 'd') ADVANCE(70);
-      if (lookahead == 'p') ADVANCE(68);
-      if (lookahead == 'q') ADVANCE(71);
-      if (lookahead == 'r') ADVANCE(58);
-      if (lookahead == 'w') ADVANCE(61);
+      if (lookahead == ':') ADVANCE(22);
+      if (lookahead == '[') ADVANCE(31);
+      if (lookahead == ']') ADVANCE(34);
+      if (lookahead == 'b') ADVANCE(73);
+      if (lookahead == 'd') ADVANCE(71);
+      if (lookahead == 'p') ADVANCE(69);
+      if (lookahead == 'q') ADVANCE(72);
+      if (lookahead == 'r') ADVANCE(59);
+      if (lookahead == 'w') ADVANCE(62);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          lookahead == '_') ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 1:
-      if (lookahead == '"') ADVANCE(54);
+      if (lookahead == '"') ADVANCE(55);
       if (lookahead != 0) ADVANCE(1);
       END_STATE();
     case 2:
       if (lookahead == '*') ADVANCE(4);
-      if (lookahead == '/') ADVANCE(82);
+      if (lookahead == '/') ADVANCE(83);
       END_STATE();
     case 3:
       if (lookahead == '*') ADVANCE(3);
-      if (lookahead == '/') ADVANCE(83);
+      if (lookahead == '/') ADVANCE(84);
       if (lookahead != 0) ADVANCE(4);
       END_STATE();
     case 4:
@@ -426,21 +450,21 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0) ADVANCE(4);
       END_STATE();
     case 5:
-      if (lookahead == '0') ADVANCE(45);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(46);
+      if (lookahead == '0') ADVANCE(46);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(47);
       END_STATE();
     case 6:
-      if (lookahead == '0') ADVANCE(47);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(48);
+      if (lookahead == '0') ADVANCE(48);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(49);
       END_STATE();
     case 7:
       if (lookahead == 'e') ADVANCE(8);
       END_STATE();
     case 8:
-      if (lookahead == 'l') ADVANCE(35);
+      if (lookahead == 'l') ADVANCE(36);
       END_STATE();
     case 9:
-      if (lookahead == 'r') ADVANCE(28);
+      if (lookahead == 'r') ADVANCE(29);
       END_STATE();
     case 10:
       if (lookahead == 't') ADVANCE(9);
@@ -450,548 +474,564 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '\r' ||
           lookahead == ' ') SKIP(11)
       if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(82);
-      if (lookahead == '%') ADVANCE(14);
+          lookahead == ';') ADVANCE(83);
+      if (lookahead == '%') ADVANCE(15);
+      if (lookahead == '-') ADVANCE(6);
+      if (lookahead == '.') ADVANCE(81);
       if (lookahead == '/') ADVANCE(2);
+      if (lookahead == '0') ADVANCE(38);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(39);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(77);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(76);
+          lookahead == '_') ADVANCE(76);
       END_STATE();
     case 12:
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(12)
       if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(82);
+          lookahead == ';') ADVANCE(83);
+      if (lookahead == '%') ADVANCE(15);
+      if (lookahead == '/') ADVANCE(2);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(78);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(77);
+      END_STATE();
+    case 13:
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(13)
+      if (lookahead == '#' ||
+          lookahead == ';') ADVANCE(83);
       if (lookahead == '/') ADVANCE(2);
       if (lookahead == 'p') ADVANCE(10);
       if (lookahead == 'r') ADVANCE(7);
       END_STATE();
-    case 13:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(49);
-      END_STATE();
     case 14:
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(78);
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(50);
       END_STATE();
     case 15:
-      if (eof) ADVANCE(18);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(15)
-      if (lookahead == '\n') ADVANCE(19);
-      if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(82);
-      if (lookahead == '%') ADVANCE(14);
-      if (lookahead == '.') ADVANCE(80);
-      if (lookahead == '/') ADVANCE(2);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(79);
       END_STATE();
     case 16:
-      if (eof) ADVANCE(18);
+      if (eof) ADVANCE(19);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(16)
-      if (lookahead == '\n') ADVANCE(19);
-      if (lookahead == '"') ADVANCE(1);
+      if (lookahead == '\n') ADVANCE(20);
       if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(82);
-      if (lookahead == '%') ADVANCE(14);
-      if (lookahead == '(') ADVANCE(21);
-      if (lookahead == '*') ADVANCE(34);
-      if (lookahead == '-') ADVANCE(5);
-      if (lookahead == '.') ADVANCE(80);
+          lookahead == ';') ADVANCE(83);
+      if (lookahead == '%') ADVANCE(15);
+      if (lookahead == '.') ADVANCE(81);
       if (lookahead == '/') ADVANCE(2);
-      if (lookahead == '0') ADVANCE(42);
-      if (lookahead == ':') ADVANCE(20);
-      if (lookahead == '[') ADVANCE(30);
-      if (lookahead == 'b') ADVANCE(72);
-      if (lookahead == 'd') ADVANCE(70);
-      if (lookahead == 'q') ADVANCE(71);
-      if (lookahead == 'w') ADVANCE(61);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(43);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          lookahead == '_') ADVANCE(76);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 17:
-      if (eof) ADVANCE(18);
+      if (eof) ADVANCE(19);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(17)
-      if (lookahead == '\n') ADVANCE(19);
+      if (lookahead == '\n') ADVANCE(20);
+      if (lookahead == '"') ADVANCE(1);
       if (lookahead == '#' ||
-          lookahead == ';') ADVANCE(82);
-      if (lookahead == '%') ADVANCE(14);
-      if (lookahead == '-') ADVANCE(6);
-      if (lookahead == '.') ADVANCE(80);
+          lookahead == ';') ADVANCE(83);
+      if (lookahead == '%') ADVANCE(15);
+      if (lookahead == '(') ADVANCE(23);
+      if (lookahead == '*') ADVANCE(35);
+      if (lookahead == '-') ADVANCE(5);
+      if (lookahead == '.') ADVANCE(81);
       if (lookahead == '/') ADVANCE(2);
-      if (lookahead == '0') ADVANCE(37);
-      if (lookahead == ':') ADVANCE(20);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(38);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+      if (lookahead == '0') ADVANCE(43);
+      if (lookahead == ':') ADVANCE(22);
+      if (lookahead == '[') ADVANCE(31);
+      if (lookahead == 'b') ADVANCE(73);
+      if (lookahead == 'd') ADVANCE(71);
+      if (lookahead == 'q') ADVANCE(72);
+      if (lookahead == 'w') ADVANCE(62);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(44);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          lookahead == '_') ADVANCE(76);
       END_STATE();
     case 18:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
+      if (eof) ADVANCE(19);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(18)
+      if (lookahead == '\n') ADVANCE(20);
+      if (lookahead == '#' ||
+          lookahead == ';') ADVANCE(83);
+      if (lookahead == '%') ADVANCE(15);
+      if (lookahead == '-') ADVANCE(5);
+      if (lookahead == '.') ADVANCE(81);
+      if (lookahead == '/') ADVANCE(2);
+      if (lookahead == '0') ADVANCE(43);
+      if (lookahead == ':') ADVANCE(22);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(44);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(76);
       END_STATE();
     case 19:
-      ACCEPT_TOKEN(anon_sym_LF);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 20:
-      ACCEPT_TOKEN(anon_sym_COLON);
+      ACCEPT_TOKEN(anon_sym_LF);
       END_STATE();
     case 21:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
-      END_STATE();
-    case 22:
-      ACCEPT_TOKEN(anon_sym_RPAREN);
-      END_STATE();
-    case 23:
       ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
+    case 22:
+      ACCEPT_TOKEN(anon_sym_COLON);
+      END_STATE();
+    case 23:
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      END_STATE();
     case 24:
-      ACCEPT_TOKEN(anon_sym_byte);
-      if (lookahead == '.') ADVANCE(81);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+      ACCEPT_TOKEN(anon_sym_RPAREN);
       END_STATE();
     case 25:
-      ACCEPT_TOKEN(anon_sym_word);
-      if (lookahead == '.') ADVANCE(81);
+      ACCEPT_TOKEN(anon_sym_byte);
+      if (lookahead == '.') ADVANCE(82);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          lookahead == '_') ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 26:
-      ACCEPT_TOKEN(anon_sym_dword);
-      if (lookahead == '.') ADVANCE(81);
+      ACCEPT_TOKEN(anon_sym_word);
+      if (lookahead == '.') ADVANCE(82);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          lookahead == '_') ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 27:
-      ACCEPT_TOKEN(anon_sym_qword);
-      if (lookahead == '.') ADVANCE(81);
+      ACCEPT_TOKEN(anon_sym_dword);
+      if (lookahead == '.') ADVANCE(82);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          lookahead == '_') ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 28:
-      ACCEPT_TOKEN(anon_sym_ptr);
+      ACCEPT_TOKEN(anon_sym_qword);
+      if (lookahead == '.') ADVANCE(82);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(76);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 29:
       ACCEPT_TOKEN(anon_sym_ptr);
-      if (lookahead == '.') ADVANCE(81);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
       END_STATE();
     case 30:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
+      ACCEPT_TOKEN(anon_sym_ptr);
+      if (lookahead == '.') ADVANCE(82);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(76);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 31:
-      ACCEPT_TOKEN(anon_sym_PLUS);
+      ACCEPT_TOKEN(anon_sym_LBRACK);
       END_STATE();
     case 32:
-      ACCEPT_TOKEN(anon_sym_DASH);
+      ACCEPT_TOKEN(anon_sym_PLUS);
       END_STATE();
     case 33:
-      ACCEPT_TOKEN(anon_sym_RBRACK);
+      ACCEPT_TOKEN(anon_sym_DASH);
       END_STATE();
     case 34:
-      ACCEPT_TOKEN(anon_sym_STAR);
+      ACCEPT_TOKEN(anon_sym_RBRACK);
       END_STATE();
     case 35:
-      ACCEPT_TOKEN(anon_sym_rel);
+      ACCEPT_TOKEN(anon_sym_STAR);
       END_STATE();
     case 36:
       ACCEPT_TOKEN(anon_sym_rel);
-      if (lookahead == '.') ADVANCE(81);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
       END_STATE();
     case 37:
-      ACCEPT_TOKEN(sym_int);
-      if (lookahead == '.') ADVANCE(81);
-      if (lookahead == '_') ADVANCE(40);
-      if (lookahead == 'x') ADVANCE(73);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(38);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(75);
+      ACCEPT_TOKEN(anon_sym_rel);
+      if (lookahead == '.') ADVANCE(82);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(76);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 38:
       ACCEPT_TOKEN(sym_int);
-      if (lookahead == '.') ADVANCE(81);
-      if (lookahead == '_') ADVANCE(40);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(38);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(75);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(82);
+      if (lookahead == '_') ADVANCE(41);
+      if (lookahead == 'x') ADVANCE(74);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(39);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(76);
       END_STATE();
     case 39:
       ACCEPT_TOKEN(sym_int);
-      if (lookahead == '.') ADVANCE(81);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          lookahead == '_') ADVANCE(41);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(39);
-      if (('G' <= lookahead && lookahead <= 'Z')) ADVANCE(75);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(82);
+      if (lookahead == '_') ADVANCE(41);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(39);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(76);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 40:
       ACCEPT_TOKEN(sym_int);
-      if (lookahead == '.') ADVANCE(81);
+      if (lookahead == '.') ADVANCE(82);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          lookahead == '_') ADVANCE(42);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(40);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(40);
+      if (('G' <= lookahead && lookahead <= 'Z')) ADVANCE(76);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 41:
       ACCEPT_TOKEN(sym_int);
-      if (lookahead == '.') ADVANCE(81);
+      if (lookahead == '.') ADVANCE(82);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(41);
-      if (('G' <= lookahead && lookahead <= 'Z') ||
-          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(75);
+          lookahead == '_') ADVANCE(41);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(76);
       END_STATE();
     case 42:
       ACCEPT_TOKEN(sym_int);
-      if (lookahead == '.') ADVANCE(50);
-      if (lookahead == '_') ADVANCE(44);
-      if (lookahead == 'x') ADVANCE(73);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(43);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(75);
+      if (lookahead == '.') ADVANCE(82);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(42);
+      if (('G' <= lookahead && lookahead <= 'Z') ||
+          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(76);
       END_STATE();
     case 43:
       ACCEPT_TOKEN(sym_int);
-      if (lookahead == '.') ADVANCE(50);
-      if (lookahead == '_') ADVANCE(44);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(43);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(75);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+      if (lookahead == '.') ADVANCE(51);
+      if (lookahead == '_') ADVANCE(45);
+      if (lookahead == 'x') ADVANCE(74);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(44);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(76);
       END_STATE();
     case 44:
       ACCEPT_TOKEN(sym_int);
-      if (lookahead == '.') ADVANCE(50);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(44);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
+      if (lookahead == '.') ADVANCE(51);
+      if (lookahead == '_') ADVANCE(45);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(44);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(76);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 45:
       ACCEPT_TOKEN(sym_int);
       if (lookahead == '.') ADVANCE(51);
-      if (lookahead == 'x') ADVANCE(13);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(46);
+          lookahead == '_') ADVANCE(45);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(76);
       END_STATE();
     case 46:
       ACCEPT_TOKEN(sym_int);
-      if (lookahead == '.') ADVANCE(51);
+      if (lookahead == '.') ADVANCE(52);
+      if (lookahead == 'x') ADVANCE(14);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(46);
+          lookahead == '_') ADVANCE(47);
       END_STATE();
     case 47:
       ACCEPT_TOKEN(sym_int);
-      if (lookahead == 'x') ADVANCE(13);
+      if (lookahead == '.') ADVANCE(52);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(48);
+          lookahead == '_') ADVANCE(47);
       END_STATE();
     case 48:
       ACCEPT_TOKEN(sym_int);
+      if (lookahead == 'x') ADVANCE(14);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(48);
+          lookahead == '_') ADVANCE(49);
       END_STATE();
     case 49:
       ACCEPT_TOKEN(sym_int);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(49);
+          lookahead == '_') ADVANCE(49);
       END_STATE();
     case 50:
-      ACCEPT_TOKEN(sym_float);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(52);
-      if (lookahead == '.' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
+      ACCEPT_TOKEN(sym_int);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(50);
       END_STATE();
     case 51:
       ACCEPT_TOKEN(sym_float);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(53);
+      if (lookahead == '.' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(82);
       END_STATE();
     case 52:
       ACCEPT_TOKEN(sym_float);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(52);
-      if (lookahead == '.' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(54);
       END_STATE();
     case 53:
       ACCEPT_TOKEN(sym_float);
       if (('0' <= lookahead && lookahead <= '9') ||
           lookahead == '_') ADVANCE(53);
+      if (lookahead == '.' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(82);
       END_STATE();
     case 54:
-      ACCEPT_TOKEN(sym_string);
+      ACCEPT_TOKEN(sym_float);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(54);
       END_STATE();
     case 55:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(81);
-      if (lookahead == 'd') ADVANCE(25);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+      ACCEPT_TOKEN(sym_string);
       END_STATE();
     case 56:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(81);
+      if (lookahead == '.') ADVANCE(82);
       if (lookahead == 'd') ADVANCE(26);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          lookahead == '_') ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 57:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(81);
+      if (lookahead == '.') ADVANCE(82);
       if (lookahead == 'd') ADVANCE(27);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          lookahead == '_') ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 58:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(81);
-      if (lookahead == 'e') ADVANCE(60);
+      if (lookahead == '.') ADVANCE(82);
+      if (lookahead == 'd') ADVANCE(28);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          lookahead == '_') ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 59:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(81);
-      if (lookahead == 'e') ADVANCE(24);
+      if (lookahead == '.') ADVANCE(82);
+      if (lookahead == 'e') ADVANCE(61);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          lookahead == '_') ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 60:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(81);
-      if (lookahead == 'l') ADVANCE(36);
+      if (lookahead == '.') ADVANCE(82);
+      if (lookahead == 'e') ADVANCE(25);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          lookahead == '_') ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 61:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(81);
-      if (lookahead == 'o') ADVANCE(65);
+      if (lookahead == '.') ADVANCE(82);
+      if (lookahead == 'l') ADVANCE(37);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          lookahead == '_') ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 62:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(81);
+      if (lookahead == '.') ADVANCE(82);
       if (lookahead == 'o') ADVANCE(66);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          lookahead == '_') ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 63:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(81);
+      if (lookahead == '.') ADVANCE(82);
       if (lookahead == 'o') ADVANCE(67);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          lookahead == '_') ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 64:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(81);
-      if (lookahead == 'r') ADVANCE(29);
+      if (lookahead == '.') ADVANCE(82);
+      if (lookahead == 'o') ADVANCE(68);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          lookahead == '_') ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 65:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(81);
-      if (lookahead == 'r') ADVANCE(55);
+      if (lookahead == '.') ADVANCE(82);
+      if (lookahead == 'r') ADVANCE(30);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          lookahead == '_') ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 66:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(81);
+      if (lookahead == '.') ADVANCE(82);
       if (lookahead == 'r') ADVANCE(56);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          lookahead == '_') ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 67:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(81);
+      if (lookahead == '.') ADVANCE(82);
       if (lookahead == 'r') ADVANCE(57);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          lookahead == '_') ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 68:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(81);
-      if (lookahead == 't') ADVANCE(64);
+      if (lookahead == '.') ADVANCE(82);
+      if (lookahead == 'r') ADVANCE(58);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          lookahead == '_') ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 69:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(81);
-      if (lookahead == 't') ADVANCE(59);
+      if (lookahead == '.') ADVANCE(82);
+      if (lookahead == 't') ADVANCE(65);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          lookahead == '_') ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 70:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(81);
-      if (lookahead == 'w') ADVANCE(62);
+      if (lookahead == '.') ADVANCE(82);
+      if (lookahead == 't') ADVANCE(60);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          lookahead == '_') ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 71:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(81);
+      if (lookahead == '.') ADVANCE(82);
       if (lookahead == 'w') ADVANCE(63);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          lookahead == '_') ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 72:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(81);
-      if (lookahead == 'y') ADVANCE(69);
+      if (lookahead == '.') ADVANCE(82);
+      if (lookahead == 'w') ADVANCE(64);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          lookahead == '_') ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 73:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(81);
-      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(41);
+      if (lookahead == '.') ADVANCE(82);
+      if (lookahead == 'y') ADVANCE(70);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(39);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(74);
-      if (('G' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 74:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(81);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(75);
+      if (lookahead == '.') ADVANCE(82);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(42);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(40);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(75);
+      if (('G' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(76);
       END_STATE();
     case 75:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(81);
+      if (lookahead == '.') ADVANCE(82);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(76);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(75);
       END_STATE();
     case 76:
       ACCEPT_TOKEN(sym_word);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(77);
+      if (lookahead == '.') ADVANCE(82);
       if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(76);
       END_STATE();
     case 77:
       ACCEPT_TOKEN(sym_word);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(78);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(77);
       END_STATE();
     case 78:
-      ACCEPT_TOKEN(sym__reg);
+      ACCEPT_TOKEN(sym_word);
       if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(78);
       END_STATE();
     case 79:
-      ACCEPT_TOKEN(sym_meta_ident);
-      if (lookahead == '_' ||
+      ACCEPT_TOKEN(sym__reg);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(79);
-      if (lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(81);
       END_STATE();
     case 80:
-      ACCEPT_TOKEN(sym__ident);
+      ACCEPT_TOKEN(sym_meta_ident);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(79);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(80);
       if (lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(81);
+          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(82);
       END_STATE();
     case 81:
+      ACCEPT_TOKEN(sym__ident);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(80);
+      if (lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(82);
+      END_STATE();
+    case 82:
       ACCEPT_TOKEN(sym__ident);
       if (lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(81);
-      END_STATE();
-    case 82:
-      ACCEPT_TOKEN(sym_line_comment);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(82);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(82);
       END_STATE();
     case 83:
+      ACCEPT_TOKEN(sym_line_comment);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(83);
+      END_STATE();
+    case 84:
       ACCEPT_TOKEN(sym_block_comment);
       END_STATE();
     default:
@@ -1001,21 +1041,21 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 15},
-  [2] = {.lex_state = 16},
-  [3] = {.lex_state = 16},
-  [4] = {.lex_state = 16},
-  [5] = {.lex_state = 16},
-  [6] = {.lex_state = 15},
-  [7] = {.lex_state = 15},
-  [8] = {.lex_state = 15},
-  [9] = {.lex_state = 17},
+  [1] = {.lex_state = 16},
+  [2] = {.lex_state = 17},
+  [3] = {.lex_state = 17},
+  [4] = {.lex_state = 17},
+  [5] = {.lex_state = 17},
+  [6] = {.lex_state = 16},
+  [7] = {.lex_state = 16},
+  [8] = {.lex_state = 16},
+  [9] = {.lex_state = 18},
   [10] = {.lex_state = 0},
-  [11] = {.lex_state = 17},
-  [12] = {.lex_state = 17},
-  [13] = {.lex_state = 15},
+  [11] = {.lex_state = 11},
+  [12] = {.lex_state = 11},
+  [13] = {.lex_state = 16},
   [14] = {.lex_state = 0},
-  [15] = {.lex_state = 15},
+  [15] = {.lex_state = 16},
   [16] = {.lex_state = 0},
   [17] = {.lex_state = 0},
   [18] = {.lex_state = 0},
@@ -1023,43 +1063,53 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [20] = {.lex_state = 0},
   [21] = {.lex_state = 0},
   [22] = {.lex_state = 0},
-  [23] = {.lex_state = 11},
+  [23] = {.lex_state = 0},
   [24] = {.lex_state = 0},
-  [25] = {.lex_state = 11},
+  [25] = {.lex_state = 0},
   [26] = {.lex_state = 0},
   [27] = {.lex_state = 0},
   [28] = {.lex_state = 0},
   [29] = {.lex_state = 0},
-  [30] = {.lex_state = 11},
+  [30] = {.lex_state = 0},
   [31] = {.lex_state = 0},
-  [32] = {.lex_state = 11},
+  [32] = {.lex_state = 12},
   [33] = {.lex_state = 0},
   [34] = {.lex_state = 0},
   [35] = {.lex_state = 0},
   [36] = {.lex_state = 0},
-  [37] = {.lex_state = 0},
-  [38] = {.lex_state = 0},
+  [37] = {.lex_state = 12},
+  [38] = {.lex_state = 12},
   [39] = {.lex_state = 12},
   [40] = {.lex_state = 0},
-  [41] = {.lex_state = 12},
+  [41] = {.lex_state = 0},
   [42] = {.lex_state = 0},
   [43] = {.lex_state = 0},
   [44] = {.lex_state = 0},
-  [45] = {.lex_state = 16},
-  [46] = {.lex_state = 0},
+  [45] = {.lex_state = 0},
+  [46] = {.lex_state = 13},
   [47] = {.lex_state = 0},
   [48] = {.lex_state = 0},
   [49] = {.lex_state = 0},
+  [50] = {.lex_state = 0},
+  [51] = {.lex_state = 17},
+  [52] = {.lex_state = 0},
+  [53] = {.lex_state = 13},
+  [54] = {.lex_state = 0},
+  [55] = {.lex_state = 0},
+  [56] = {.lex_state = 0},
+  [57] = {.lex_state = 17},
+  [58] = {.lex_state = 0},
+  [59] = {.lex_state = 17},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   [0] = {
     [ts_builtin_sym_end] = ACTIONS(1),
     [anon_sym_LF] = ACTIONS(1),
+    [anon_sym_COMMA] = ACTIONS(1),
     [anon_sym_COLON] = ACTIONS(1),
     [anon_sym_LPAREN] = ACTIONS(1),
     [anon_sym_RPAREN] = ACTIONS(1),
-    [anon_sym_COMMA] = ACTIONS(1),
     [anon_sym_byte] = ACTIONS(1),
     [anon_sym_word] = ACTIONS(1),
     [anon_sym_dword] = ACTIONS(1),
@@ -1080,13 +1130,13 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_block_comment] = ACTIONS(3),
   },
   [1] = {
-    [sym_program] = STATE(43),
-    [sym__item] = STATE(22),
-    [sym_meta] = STATE(22),
-    [sym_label] = STATE(22),
-    [sym_instruction] = STATE(22),
+    [sym_program] = STATE(56),
+    [sym__item] = STATE(19),
+    [sym_meta] = STATE(19),
+    [sym_label] = STATE(19),
+    [sym_instruction] = STATE(19),
     [sym_reg] = STATE(14),
-    [sym_ident] = STATE(46),
+    [sym_ident] = STATE(55),
     [ts_builtin_sym_end] = ACTIONS(5),
     [sym_word] = ACTIONS(7),
     [sym__reg] = ACTIONS(9),
@@ -1096,10 +1146,10 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_block_comment] = ACTIONS(3),
   },
   [2] = {
-    [sym__expr] = STATE(16),
-    [sym_ptr] = STATE(16),
+    [sym__expr] = STATE(28),
+    [sym_ptr] = STATE(28),
     [sym_reg] = STATE(14),
-    [sym_ident] = STATE(16),
+    [sym_ident] = STATE(28),
     [ts_builtin_sym_end] = ACTIONS(15),
     [anon_sym_LF] = ACTIONS(15),
     [anon_sym_COLON] = ACTIONS(17),
@@ -1121,10 +1171,10 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_block_comment] = ACTIONS(3),
   },
   [3] = {
-    [sym__expr] = STATE(34),
-    [sym_ptr] = STATE(34),
+    [sym__expr] = STATE(42),
+    [sym_ptr] = STATE(42),
     [sym_reg] = STATE(14),
-    [sym_ident] = STATE(34),
+    [sym_ident] = STATE(42),
     [ts_builtin_sym_end] = ACTIONS(33),
     [anon_sym_LF] = ACTIONS(33),
     [anon_sym_LPAREN] = ACTIONS(19),
@@ -1145,34 +1195,12 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_block_comment] = ACTIONS(3),
   },
   [4] = {
-    [sym__expr] = STATE(34),
-    [sym_ptr] = STATE(34),
+    [sym__expr] = STATE(42),
+    [sym_ptr] = STATE(42),
     [sym_reg] = STATE(14),
-    [sym_ident] = STATE(34),
+    [sym_ident] = STATE(42),
     [ts_builtin_sym_end] = ACTIONS(39),
     [anon_sym_LF] = ACTIONS(39),
-    [anon_sym_LPAREN] = ACTIONS(19),
-    [anon_sym_byte] = ACTIONS(21),
-    [anon_sym_word] = ACTIONS(21),
-    [anon_sym_dword] = ACTIONS(21),
-    [anon_sym_qword] = ACTIONS(21),
-    [anon_sym_LBRACK] = ACTIONS(23),
-    [anon_sym_STAR] = ACTIONS(25),
-    [sym_int] = ACTIONS(27),
-    [sym_float] = ACTIONS(35),
-    [sym_string] = ACTIONS(37),
-    [sym_word] = ACTIONS(9),
-    [sym__reg] = ACTIONS(9),
-    [sym_meta_ident] = ACTIONS(13),
-    [sym__ident] = ACTIONS(13),
-    [sym_line_comment] = ACTIONS(3),
-    [sym_block_comment] = ACTIONS(3),
-  },
-  [5] = {
-    [sym__expr] = STATE(34),
-    [sym_ptr] = STATE(34),
-    [sym_reg] = STATE(14),
-    [sym_ident] = STATE(34),
     [anon_sym_LPAREN] = ACTIONS(19),
     [anon_sym_byte] = ACTIONS(21),
     [anon_sym_word] = ACTIONS(21),
@@ -1193,7 +1221,40 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 11,
+  [0] = 12,
+    ACTIONS(19), 1,
+      anon_sym_LPAREN,
+    ACTIONS(23), 1,
+      anon_sym_LBRACK,
+    ACTIONS(25), 1,
+      anon_sym_STAR,
+    ACTIONS(27), 1,
+      sym_int,
+    ACTIONS(35), 1,
+      sym_float,
+    ACTIONS(37), 1,
+      sym_string,
+    STATE(14), 1,
+      sym_reg,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+    ACTIONS(9), 2,
+      sym_word,
+      sym__reg,
+    ACTIONS(13), 2,
+      sym_meta_ident,
+      sym__ident,
+    STATE(42), 3,
+      sym__expr,
+      sym_ptr,
+      sym_ident,
+    ACTIONS(21), 4,
+      anon_sym_byte,
+      anon_sym_word,
+      anon_sym_dword,
+      anon_sym_qword,
+  [45] = 11,
     ACTIONS(7), 1,
       sym_word,
     ACTIONS(9), 1,
@@ -1210,17 +1271,17 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_program_repeat1,
     STATE(14), 1,
       sym_reg,
-    STATE(46), 1,
+    STATE(55), 1,
       sym_ident,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
-    STATE(35), 4,
+    STATE(44), 4,
       sym__item,
       sym_meta,
       sym_label,
       sym_instruction,
-  [38] = 11,
+  [83] = 11,
     ACTIONS(7), 1,
       sym_word,
     ACTIONS(9), 1,
@@ -1237,17 +1298,17 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_program_repeat1,
     STATE(14), 1,
       sym_reg,
-    STATE(46), 1,
+    STATE(55), 1,
       sym_ident,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
-    STATE(35), 4,
+    STATE(44), 4,
       sym__item,
       sym_meta,
       sym_label,
       sym_instruction,
-  [76] = 10,
+  [121] = 10,
     ACTIONS(7), 1,
       sym_word,
     ACTIONS(9), 1,
@@ -1262,24 +1323,26 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_program_repeat1,
     STATE(14), 1,
       sym_reg,
-    STATE(46), 1,
+    STATE(55), 1,
       sym_ident,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
-    STATE(35), 4,
+    STATE(44), 4,
       sym__item,
       sym_meta,
       sym_label,
       sym_instruction,
-  [111] = 8,
+  [156] = 9,
     ACTIONS(49), 1,
       anon_sym_COLON,
     ACTIONS(51), 1,
       sym_int,
+    ACTIONS(53), 1,
+      sym_float,
     STATE(14), 1,
       sym_reg,
-    STATE(37), 1,
+    STATE(43), 1,
       sym_ident,
     ACTIONS(3), 2,
       sym_line_comment,
@@ -1293,41 +1356,25 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(47), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [140] = 2,
+  [188] = 2,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
     ACTIONS(17), 8,
       ts_builtin_sym_end,
       anon_sym_LF,
+      anon_sym_COMMA,
       anon_sym_COLON,
       anon_sym_RPAREN,
-      anon_sym_COMMA,
       anon_sym_PLUS,
       anon_sym_DASH,
       anon_sym_RBRACK,
-  [155] = 6,
-    ACTIONS(53), 1,
-      sym_int,
-    STATE(14), 1,
-      sym_reg,
-    STATE(42), 1,
-      sym_ident,
-    ACTIONS(3), 2,
-      sym_line_comment,
-      sym_block_comment,
-    ACTIONS(9), 2,
-      sym_word,
-      sym__reg,
-    ACTIONS(13), 2,
-      sym_meta_ident,
-      sym__ident,
-  [177] = 6,
+  [203] = 6,
     ACTIONS(55), 1,
       sym_int,
     STATE(14), 1,
       sym_reg,
-    STATE(48), 1,
+    STATE(58), 1,
       sym_ident,
     ACTIONS(3), 2,
       sym_line_comment,
@@ -1338,36 +1385,52 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(13), 2,
       sym_meta_ident,
       sym__ident,
-  [199] = 5,
+  [225] = 6,
     ACTIONS(57), 1,
-      ts_builtin_sym_end,
+      sym_int,
+    STATE(14), 1,
+      sym_reg,
+    STATE(54), 1,
+      sym_ident,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+    ACTIONS(9), 2,
+      sym_word,
+      sym__reg,
+    ACTIONS(13), 2,
+      sym_meta_ident,
+      sym__ident,
+  [247] = 5,
     ACTIONS(59), 1,
+      ts_builtin_sym_end,
+    ACTIONS(61), 1,
       anon_sym_LF,
     STATE(13), 1,
       aux_sym_program_repeat1,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
-    ACTIONS(62), 4,
+    ACTIONS(64), 4,
       sym_word,
       sym__reg,
       sym_meta_ident,
       sym__ident,
-  [219] = 2,
+  [267] = 2,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
     ACTIONS(49), 6,
       ts_builtin_sym_end,
       anon_sym_LF,
+      anon_sym_COMMA,
       anon_sym_COLON,
       anon_sym_RPAREN,
-      anon_sym_COMMA,
       anon_sym_RBRACK,
-  [232] = 5,
+  [280] = 5,
     STATE(14), 1,
       sym_reg,
-    STATE(40), 1,
+    STATE(52), 1,
       sym_ident,
     ACTIONS(3), 2,
       sym_line_comment,
@@ -1378,177 +1441,152 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(13), 2,
       sym_meta_ident,
       sym__ident,
-  [251] = 4,
-    ACTIONS(66), 1,
-      anon_sym_COMMA,
-    STATE(17), 1,
-      aux_sym_instruction_repeat1,
-    ACTIONS(3), 2,
-      sym_line_comment,
-      sym_block_comment,
-    ACTIONS(64), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-  [266] = 4,
+  [299] = 4,
     ACTIONS(68), 1,
       anon_sym_COMMA,
     STATE(21), 1,
-      aux_sym_instruction_repeat1,
+      aux_sym_meta_repeat2,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
-    ACTIONS(33), 2,
+    ACTIONS(66), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [281] = 5,
-    ACTIONS(45), 1,
-      ts_builtin_sym_end,
+  [314] = 4,
     ACTIONS(70), 1,
+      anon_sym_COMMA,
+    STATE(22), 1,
+      aux_sym_meta_repeat1,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+    ACTIONS(66), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [329] = 4,
+    ACTIONS(68), 1,
+      anon_sym_COMMA,
+    STATE(16), 1,
+      aux_sym_meta_repeat2,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+    ACTIONS(72), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [344] = 5,
+    ACTIONS(74), 1,
+      ts_builtin_sym_end,
+    ACTIONS(76), 1,
       anon_sym_LF,
     STATE(6), 1,
       aux_sym_program_repeat1,
-    STATE(19), 1,
+    STATE(20), 1,
       aux_sym_program_repeat2,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
-  [298] = 5,
-    ACTIONS(72), 1,
+  [361] = 5,
+    ACTIONS(41), 1,
       ts_builtin_sym_end,
-    ACTIONS(74), 1,
+    ACTIONS(78), 1,
       anon_sym_LF,
-    STATE(8), 1,
+    STATE(7), 1,
       aux_sym_program_repeat1,
-    STATE(19), 1,
+    STATE(25), 1,
       aux_sym_program_repeat2,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
-  [315] = 3,
-    ACTIONS(79), 1,
-      anon_sym_LPAREN,
-    ACTIONS(3), 2,
-      sym_line_comment,
-      sym_block_comment,
-    ACTIONS(77), 3,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_COMMA,
-  [328] = 4,
-    ACTIONS(83), 1,
+  [378] = 4,
+    ACTIONS(82), 1,
       anon_sym_COMMA,
     STATE(21), 1,
+      aux_sym_meta_repeat2,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+    ACTIONS(80), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [393] = 4,
+    ACTIONS(87), 1,
+      anon_sym_COMMA,
+    STATE(22), 1,
+      aux_sym_meta_repeat1,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+    ACTIONS(85), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [408] = 4,
+    ACTIONS(92), 1,
+      anon_sym_COMMA,
+    STATE(23), 1,
       aux_sym_instruction_repeat1,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
-    ACTIONS(81), 2,
+    ACTIONS(90), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [343] = 5,
-    ACTIONS(86), 1,
+  [423] = 3,
+    ACTIONS(97), 1,
+      anon_sym_LPAREN,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+    ACTIONS(95), 3,
       ts_builtin_sym_end,
-    ACTIONS(88), 1,
       anon_sym_LF,
-    STATE(7), 1,
+      anon_sym_COMMA,
+  [436] = 5,
+    ACTIONS(99), 1,
+      ts_builtin_sym_end,
+    ACTIONS(101), 1,
+      anon_sym_LF,
+    STATE(8), 1,
       aux_sym_program_repeat1,
-    STATE(18), 1,
+    STATE(25), 1,
       aux_sym_program_repeat2,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
-  [360] = 4,
-    ACTIONS(9), 1,
-      sym__reg,
-    ACTIONS(90), 1,
-      sym_word,
-    STATE(27), 1,
-      sym_reg,
+  [453] = 4,
+    ACTIONS(70), 1,
+      anon_sym_COMMA,
+    STATE(17), 1,
+      aux_sym_meta_repeat1,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
-  [374] = 3,
-    ACTIONS(94), 1,
-      anon_sym_RBRACK,
-    ACTIONS(3), 2,
-      sym_line_comment,
-      sym_block_comment,
-    ACTIONS(92), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-  [386] = 4,
-    ACTIONS(9), 1,
-      sym__reg,
-    ACTIONS(90), 1,
-      sym_word,
-    STATE(44), 1,
-      sym_reg,
-    ACTIONS(3), 2,
-      sym_line_comment,
-      sym_block_comment,
-  [400] = 2,
-    ACTIONS(3), 2,
-      sym_line_comment,
-      sym_block_comment,
-    ACTIONS(96), 3,
+    ACTIONS(72), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
+  [468] = 4,
+    ACTIONS(104), 1,
       anon_sym_COMMA,
-  [410] = 3,
-    ACTIONS(100), 1,
-      anon_sym_RBRACK,
+    STATE(23), 1,
+      aux_sym_instruction_repeat1,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
-    ACTIONS(98), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-  [422] = 2,
-    ACTIONS(3), 2,
-      sym_line_comment,
-      sym_block_comment,
-    ACTIONS(102), 3,
+    ACTIONS(39), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-      anon_sym_COMMA,
-  [432] = 2,
-    ACTIONS(3), 2,
-      sym_line_comment,
-      sym_block_comment,
-    ACTIONS(104), 3,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_COMMA,
-  [442] = 4,
-    ACTIONS(9), 1,
-      sym__reg,
-    ACTIONS(90), 1,
-      sym_word,
-    STATE(24), 1,
-      sym_reg,
-    ACTIONS(3), 2,
-      sym_line_comment,
-      sym_block_comment,
-  [456] = 3,
+  [483] = 4,
     ACTIONS(108), 1,
-      anon_sym_LPAREN,
+      anon_sym_COMMA,
+    STATE(27), 1,
+      aux_sym_instruction_repeat1,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
     ACTIONS(106), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [468] = 4,
-    ACTIONS(9), 1,
-      sym__reg,
-    ACTIONS(90), 1,
-      sym_word,
-    STATE(38), 1,
-      sym_reg,
-    ACTIONS(3), 2,
-      sym_line_comment,
-      sym_block_comment,
-  [482] = 2,
+  [498] = 2,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
@@ -1556,154 +1594,284 @@ static const uint16_t ts_small_parse_table[] = {
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [492] = 2,
+  [508] = 3,
+    ACTIONS(114), 1,
+      anon_sym_RBRACK,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
-    ACTIONS(81), 3,
+    ACTIONS(112), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+  [520] = 2,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+    ACTIONS(116), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [502] = 2,
+  [530] = 4,
+    ACTIONS(9), 1,
+      sym__reg,
+    ACTIONS(118), 1,
+      sym_word,
+    STATE(49), 1,
+      sym_reg,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+  [544] = 2,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+    ACTIONS(120), 3,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+  [554] = 3,
+    ACTIONS(124), 1,
+      anon_sym_LPAREN,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+    ACTIONS(122), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [566] = 2,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+    ACTIONS(126), 3,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+  [576] = 3,
+    ACTIONS(130), 1,
+      anon_sym_RBRACK,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+    ACTIONS(128), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+  [588] = 4,
+    ACTIONS(9), 1,
+      sym__reg,
+    ACTIONS(118), 1,
+      sym_word,
+    STATE(50), 1,
+      sym_reg,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+  [602] = 4,
+    ACTIONS(9), 1,
+      sym__reg,
+    ACTIONS(118), 1,
+      sym_word,
+    STATE(36), 1,
+      sym_reg,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+  [616] = 4,
+    ACTIONS(9), 1,
+      sym__reg,
+    ACTIONS(118), 1,
+      sym_word,
+    STATE(30), 1,
+      sym_reg,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+  [630] = 2,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+    ACTIONS(80), 3,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+  [640] = 2,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+    ACTIONS(85), 3,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+  [650] = 2,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+    ACTIONS(90), 3,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+  [660] = 2,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
     ACTIONS(72), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [511] = 2,
+  [669] = 2,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
-    ACTIONS(112), 2,
+    ACTIONS(99), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [520] = 2,
+  [678] = 2,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
-    ACTIONS(114), 2,
+    ACTIONS(132), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [529] = 2,
-    ACTIONS(100), 1,
-      anon_sym_RPAREN,
-    ACTIONS(3), 2,
-      sym_line_comment,
-      sym_block_comment,
-  [537] = 2,
-    ACTIONS(116), 1,
+  [687] = 2,
+    ACTIONS(134), 1,
       anon_sym_ptr,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
-  [545] = 2,
-    ACTIONS(118), 1,
+  [695] = 2,
+    ACTIONS(136), 1,
+      anon_sym_LBRACK,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+  [703] = 2,
+    ACTIONS(138), 1,
+      anon_sym_LBRACK,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+  [711] = 2,
+    ACTIONS(140), 1,
       anon_sym_RPAREN,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
-  [553] = 2,
-    ACTIONS(120), 1,
-      anon_sym_rel,
-    ACTIONS(3), 2,
-      sym_line_comment,
-      sym_block_comment,
-  [561] = 2,
-    ACTIONS(94), 1,
-      anon_sym_RBRACK,
-    ACTIONS(3), 2,
-      sym_line_comment,
-      sym_block_comment,
-  [569] = 2,
-    ACTIONS(122), 1,
-      ts_builtin_sym_end,
-    ACTIONS(3), 2,
-      sym_line_comment,
-      sym_block_comment,
-  [577] = 2,
-    ACTIONS(124), 1,
+  [719] = 2,
+    ACTIONS(114), 1,
       anon_sym_RPAREN,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
-  [585] = 2,
-    ACTIONS(126), 1,
+  [727] = 2,
+    ACTIONS(142), 1,
       sym_int,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
-  [593] = 2,
-    ACTIONS(128), 1,
-      anon_sym_COLON,
+  [735] = 2,
+    ACTIONS(144), 1,
+      anon_sym_RPAREN,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
-  [601] = 2,
+  [743] = 2,
+    ACTIONS(146), 1,
+      anon_sym_rel,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+  [751] = 2,
     ACTIONS(130), 1,
-      anon_sym_LBRACK,
-    ACTIONS(3), 2,
-      sym_line_comment,
-      sym_block_comment,
-  [609] = 2,
-    ACTIONS(132), 1,
       anon_sym_RBRACK,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
-  [617] = 2,
-    ACTIONS(134), 1,
-      anon_sym_LBRACK,
+  [759] = 2,
+    ACTIONS(148), 1,
+      anon_sym_COLON,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+  [767] = 2,
+    ACTIONS(150), 1,
+      ts_builtin_sym_end,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+  [775] = 2,
+    ACTIONS(152), 1,
+      sym_float,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+  [783] = 2,
+    ACTIONS(154), 1,
+      anon_sym_RBRACK,
+    ACTIONS(3), 2,
+      sym_line_comment,
+      sym_block_comment,
+  [791] = 2,
+    ACTIONS(156), 1,
+      sym_int,
     ACTIONS(3), 2,
       sym_line_comment,
       sym_block_comment,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
-  [SMALL_STATE(6)] = 0,
-  [SMALL_STATE(7)] = 38,
-  [SMALL_STATE(8)] = 76,
-  [SMALL_STATE(9)] = 111,
-  [SMALL_STATE(10)] = 140,
-  [SMALL_STATE(11)] = 155,
-  [SMALL_STATE(12)] = 177,
-  [SMALL_STATE(13)] = 199,
-  [SMALL_STATE(14)] = 219,
-  [SMALL_STATE(15)] = 232,
-  [SMALL_STATE(16)] = 251,
-  [SMALL_STATE(17)] = 266,
-  [SMALL_STATE(18)] = 281,
-  [SMALL_STATE(19)] = 298,
-  [SMALL_STATE(20)] = 315,
-  [SMALL_STATE(21)] = 328,
-  [SMALL_STATE(22)] = 343,
-  [SMALL_STATE(23)] = 360,
-  [SMALL_STATE(24)] = 374,
-  [SMALL_STATE(25)] = 386,
-  [SMALL_STATE(26)] = 400,
-  [SMALL_STATE(27)] = 410,
-  [SMALL_STATE(28)] = 422,
-  [SMALL_STATE(29)] = 432,
-  [SMALL_STATE(30)] = 442,
-  [SMALL_STATE(31)] = 456,
-  [SMALL_STATE(32)] = 468,
-  [SMALL_STATE(33)] = 482,
-  [SMALL_STATE(34)] = 492,
-  [SMALL_STATE(35)] = 502,
-  [SMALL_STATE(36)] = 511,
-  [SMALL_STATE(37)] = 520,
-  [SMALL_STATE(38)] = 529,
-  [SMALL_STATE(39)] = 537,
-  [SMALL_STATE(40)] = 545,
-  [SMALL_STATE(41)] = 553,
-  [SMALL_STATE(42)] = 561,
-  [SMALL_STATE(43)] = 569,
-  [SMALL_STATE(44)] = 577,
-  [SMALL_STATE(45)] = 585,
-  [SMALL_STATE(46)] = 593,
-  [SMALL_STATE(47)] = 601,
-  [SMALL_STATE(48)] = 609,
-  [SMALL_STATE(49)] = 617,
+  [SMALL_STATE(5)] = 0,
+  [SMALL_STATE(6)] = 45,
+  [SMALL_STATE(7)] = 83,
+  [SMALL_STATE(8)] = 121,
+  [SMALL_STATE(9)] = 156,
+  [SMALL_STATE(10)] = 188,
+  [SMALL_STATE(11)] = 203,
+  [SMALL_STATE(12)] = 225,
+  [SMALL_STATE(13)] = 247,
+  [SMALL_STATE(14)] = 267,
+  [SMALL_STATE(15)] = 280,
+  [SMALL_STATE(16)] = 299,
+  [SMALL_STATE(17)] = 314,
+  [SMALL_STATE(18)] = 329,
+  [SMALL_STATE(19)] = 344,
+  [SMALL_STATE(20)] = 361,
+  [SMALL_STATE(21)] = 378,
+  [SMALL_STATE(22)] = 393,
+  [SMALL_STATE(23)] = 408,
+  [SMALL_STATE(24)] = 423,
+  [SMALL_STATE(25)] = 436,
+  [SMALL_STATE(26)] = 453,
+  [SMALL_STATE(27)] = 468,
+  [SMALL_STATE(28)] = 483,
+  [SMALL_STATE(29)] = 498,
+  [SMALL_STATE(30)] = 508,
+  [SMALL_STATE(31)] = 520,
+  [SMALL_STATE(32)] = 530,
+  [SMALL_STATE(33)] = 544,
+  [SMALL_STATE(34)] = 554,
+  [SMALL_STATE(35)] = 566,
+  [SMALL_STATE(36)] = 576,
+  [SMALL_STATE(37)] = 588,
+  [SMALL_STATE(38)] = 602,
+  [SMALL_STATE(39)] = 616,
+  [SMALL_STATE(40)] = 630,
+  [SMALL_STATE(41)] = 640,
+  [SMALL_STATE(42)] = 650,
+  [SMALL_STATE(43)] = 660,
+  [SMALL_STATE(44)] = 669,
+  [SMALL_STATE(45)] = 678,
+  [SMALL_STATE(46)] = 687,
+  [SMALL_STATE(47)] = 695,
+  [SMALL_STATE(48)] = 703,
+  [SMALL_STATE(49)] = 711,
+  [SMALL_STATE(50)] = 719,
+  [SMALL_STATE(51)] = 727,
+  [SMALL_STATE(52)] = 735,
+  [SMALL_STATE(53)] = 743,
+  [SMALL_STATE(54)] = 751,
+  [SMALL_STATE(55)] = 759,
+  [SMALL_STATE(56)] = 767,
+  [SMALL_STATE(57)] = 775,
+  [SMALL_STATE(58)] = 783,
+  [SMALL_STATE(59)] = 791,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -1717,63 +1885,73 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
   [15] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 1, .production_id = 1),
   [17] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_reg, 1),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
-  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(39),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
-  [27] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
-  [29] = {.entry = {.count = 1, .reusable = false}}, SHIFT(16),
-  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [33] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 3, .production_id = 1),
-  [35] = {.entry = {.count = 1, .reusable = false}}, SHIFT(34),
-  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [39] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 4, .production_id = 1),
-  [41] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 3),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(46),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [27] = {.entry = {.count = 1, .reusable = false}}, SHIFT(24),
+  [29] = {.entry = {.count = 1, .reusable = false}}, SHIFT(28),
+  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [33] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 4, .production_id = 1),
+  [35] = {.entry = {.count = 1, .reusable = false}}, SHIFT(42),
+  [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
+  [39] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 3, .production_id = 1),
+  [41] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 2),
   [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [45] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 2),
+  [45] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 3),
   [47] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 1, .production_id = 1),
   [49] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ident, 1),
-  [51] = {.entry = {.count = 1, .reusable = false}}, SHIFT(37),
-  [53] = {.entry = {.count = 1, .reusable = false}}, SHIFT(42),
-  [55] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
-  [57] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2),
-  [59] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(13),
-  [62] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2),
-  [64] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 2, .production_id = 1),
-  [66] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [68] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [70] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
-  [72] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat2, 2),
-  [74] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat2, 2), SHIFT_REPEAT(8),
-  [77] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expr, 1),
-  [79] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
-  [81] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_instruction_repeat1, 2),
-  [83] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_instruction_repeat1, 2), SHIFT_REPEAT(5),
-  [86] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 1),
-  [88] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [90] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [92] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [94] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [96] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 7),
-  [98] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
-  [100] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
-  [102] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 5),
-  [104] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 3),
-  [106] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 2),
-  [108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
-  [110] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 4),
-  [112] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 5),
-  [114] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 2, .production_id = 1),
-  [116] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
-  [118] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
-  [120] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
-  [122] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [124] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
-  [126] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
-  [128] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [130] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
-  [132] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
-  [134] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [51] = {.entry = {.count = 1, .reusable = false}}, SHIFT(26),
+  [53] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
+  [55] = {.entry = {.count = 1, .reusable = false}}, SHIFT(58),
+  [57] = {.entry = {.count = 1, .reusable = false}}, SHIFT(54),
+  [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2),
+  [61] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(13),
+  [64] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2),
+  [66] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 3, .production_id = 1),
+  [68] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [70] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [72] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 2, .production_id = 1),
+  [74] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 1),
+  [76] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [78] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [80] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat2, 2),
+  [82] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat2, 2), SHIFT_REPEAT(57),
+  [85] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat1, 2),
+  [87] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat1, 2), SHIFT_REPEAT(59),
+  [90] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_instruction_repeat1, 2),
+  [92] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_instruction_repeat1, 2), SHIFT_REPEAT(5),
+  [95] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expr, 1),
+  [97] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [99] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat2, 2),
+  [101] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat2, 2), SHIFT_REPEAT(8),
+  [104] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [106] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 2, .production_id = 1),
+  [108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [110] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 3),
+  [112] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [114] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [116] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 7),
+  [118] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [120] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 5),
+  [122] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 2),
+  [124] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [126] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 4),
+  [128] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [130] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [132] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 5),
+  [134] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
+  [136] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [138] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [140] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [142] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [144] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [146] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
+  [148] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [150] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [152] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [154] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [156] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
Would it be possible to add support for multiple items in a comma separated list after a meta identifier, for example:
```asm
.long 1, 2, 3
```

Relevant example docs: https://sourceware.org/binutils/docs-2.41/as/Int.html

I tested this using a simple file with the following contents:

```asm
data_items:
    .long 1, 2, 3
```

Output of tree-sitter's parsing before the change:
```(program [0, 0] - [2, 0]
  (label [0, 0] - [0, 11]
    (ident [0, 0] - [0, 10]
      (reg [0, 0] - [0, 10]
        (word [0, 0] - [0, 10]))))
  (meta [1, 4] - [1, 11]
    kind: (meta_ident [1, 4] - [1, 9])
    (int [1, 10] - [1, 11]))
  (ERROR [1, 11] - [1, 17]
    (word [1, 13] - [1, 14])
    (word [1, 16] - [1, 17])))
example.asm     0 ms    (ERROR [1, 11] - [1, 17])
```

And after:

```(program [0, 0] - [2, 0]
  (label [0, 0] - [0, 11]
    (ident [0, 0] - [0, 10]
      (reg [0, 0] - [0, 10]
        (word [0, 0] - [0, 10]))))
  (meta [1, 4] - [1, 17]
    kind: (meta_ident [1, 4] - [1, 9])
    (int [1, 10] - [1, 11])
    (int [1, 13] - [1, 14])
    (int [1, 16] - [1, 17])))
```